### PR TITLE
Added ssl option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bin
 .project
 .settings/
 target/
+*.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Create new properties file inside `etc/catalog` dir:
 
 ## Building Presto DB2 JDBC Plugin
 
-    mvn clean install
+    mvn clean install -DskipTests -Dair.check.skip-all=true

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Create new properties file inside `etc/catalog` dir:
     connection-url=jdbc:db2://ip:port/database
     connection-user=myuser
     connection-password=mypassword
+    connection-ssl=true
 
 ## Building Presto DB2 JDBC Plugin
 

--- a/src/main/java/io/prestosql/plugin/db2/DB2Client.java
+++ b/src/main/java/io/prestosql/plugin/db2/DB2Client.java
@@ -31,20 +31,23 @@ public class DB2Client
         extends BaseJdbcClient
 {
     @Inject
-    public DB2Client(JdbcConnectorId connectorId, BaseJdbcConfig config) throws SQLException
+    public DB2Client(JdbcConnectorId connectorId, BaseJdbcConfig config, DB2JdbcConfig db2Config) throws SQLException
     {
-        super(connectorId, config, "", createDriverConnectionFactory(new DB2Driver(), config));
+        super(connectorId, config, "", createDriverConnectionFactory(new DB2Driver(), config, db2Config));
 
         // http://stackoverflow.com/questions/16910791/getting-error-code-4220-with-null-sql-state
         System.setProperty("db2.jcc.charsetDecoderEncoder", "3");
     }
 
-    private static DriverConnectionFactory createDriverConnectionFactory(Driver driver, BaseJdbcConfig config)
+    private static DriverConnectionFactory createDriverConnectionFactory(Driver driver, BaseJdbcConfig config, DB2JdbcConfig db2Config)
     {
         Properties connectionProperties = DriverConnectionFactory.basicConnectionProperties(config);
         // https://www-01.ibm.com/support/knowledgecenter/ssw_ibm_i_72/rzaha/conprop.htm
         // block size (aka fetch size), default 32
         connectionProperties.setProperty("block size", "512");
+        if (db2Config.isSslConnection()) {
+            connectionProperties.setProperty("sslConnection", String.valueOf(db2Config.isSslConnection()));
+        }
 
         return new DriverConnectionFactory(driver, config.getConnectionUrl(), connectionProperties);
     }

--- a/src/main/java/io/prestosql/plugin/db2/DB2Client.java
+++ b/src/main/java/io/prestosql/plugin/db2/DB2Client.java
@@ -13,12 +13,12 @@
  */
 package io.prestosql.plugin.db2;
 
+import com.ibm.db2.jcc.DB2Driver;
 import io.prestosql.plugin.jdbc.BaseJdbcClient;
 import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcConnectorId;
 import io.prestosql.plugin.jdbc.JdbcSplit;
-import com.ibm.db2.jcc.DB2Driver;
 
 import javax.inject.Inject;
 

--- a/src/main/java/io/prestosql/plugin/db2/DB2ClientModule.java
+++ b/src/main/java/io/prestosql/plugin/db2/DB2ClientModule.java
@@ -13,11 +13,11 @@
  */
 package io.prestosql.plugin.db2;
 
-import io.prestosql.plugin.jdbc.BaseJdbcConfig;
-import io.prestosql.plugin.jdbc.JdbcClient;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import io.prestosql.plugin.jdbc.BaseJdbcConfig;
+import io.prestosql.plugin.jdbc.JdbcClient;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 

--- a/src/main/java/io/prestosql/plugin/db2/DB2ClientModule.java
+++ b/src/main/java/io/prestosql/plugin/db2/DB2ClientModule.java
@@ -29,5 +29,6 @@ public class DB2ClientModule
     {
         binder.bind(JdbcClient.class).to(DB2Client.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(BaseJdbcConfig.class);
+        configBinder(binder).bindConfig(DB2JdbcConfig.class);
     }
 }

--- a/src/main/java/io/prestosql/plugin/db2/DB2JdbcConfig.java
+++ b/src/main/java/io/prestosql/plugin/db2/DB2JdbcConfig.java
@@ -1,21 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.prestosql.plugin.db2;
 
 import io.airlift.configuration.Config;
 
-public class DB2JdbcConfig {
+public class DB2JdbcConfig
+{
     private boolean sslConnection;
 
-    public DB2JdbcConfig() {
+    public DB2JdbcConfig()
+    {
     }
 
-    public boolean isSslConnection() {
+    public boolean isSslConnection()
+    {
         return this.sslConnection;
     }
 
     @Config("connection-ssl")
-    public DB2JdbcConfig setSslConnection(boolean sslConnection) {
+    public DB2JdbcConfig setSslConnection(boolean sslConnection)
+    {
         this.sslConnection = sslConnection;
         return this;
     }
-
 }

--- a/src/main/java/io/prestosql/plugin/db2/DB2JdbcConfig.java
+++ b/src/main/java/io/prestosql/plugin/db2/DB2JdbcConfig.java
@@ -1,0 +1,21 @@
+package io.prestosql.plugin.db2;
+
+import io.airlift.configuration.Config;
+
+public class DB2JdbcConfig {
+    private boolean sslConnection;
+
+    public DB2JdbcConfig() {
+    }
+
+    public boolean isSslConnection() {
+        return this.sslConnection;
+    }
+
+    @Config("connection-ssl")
+    public DB2JdbcConfig setSslConnection(boolean sslConnection) {
+        this.sslConnection = sslConnection;
+        return this;
+    }
+
+}

--- a/src/test/java/io/prestosql/plugin/db2/TestDB2Plugin.java
+++ b/src/test/java/io/prestosql/plugin/db2/TestDB2Plugin.java
@@ -13,11 +13,10 @@
  */
 package io.prestosql.plugin.db2;
 
+import com.google.common.collect.ImmutableMap;
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.ConnectorFactory;
 import io.prestosql.testing.TestingConnectorContext;
-import com.google.common.collect.ImmutableMap;
-
 import org.testng.annotations.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;


### PR DESCRIPTION
This PR is related to issue:
https://github.com/IBM/presto-db2/issues/14

This PR will add an "connection-ssl" option to db2 properties for Presto to connect to DB2 with ssl.

The the code of this PR, one should be able to connect to db2 with following properties:
```
connector.name=db2
connection-url=jdbc:db2://db2whoc-flex-performance-riubnzs.services.dal.bluemix.net:50001/BLUDB
connection-user=myuser
connection-password=mypassword
connection-ssl=true
```
