### PR TITLE
Keep consistent with trinodb CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         java-version:
         - 11
-        - 14
+        - 15
     env:
       MAVEN_SKIP_CHECKS_AND_DOCS: -Dair.check.skip-all=true -Dmaven.javadoc.skip=true
       MAVEN_FAST_INSTALL: -DskipTests -Dair.check.skip-all=true -Dmaven.javadoc.skip=true -B -q -T C1


### PR DESCRIPTION
Uses JDK 15 instead of JDK 14